### PR TITLE
Added tests for tmp.fix

### DIFF
--- a/test/util.tmp.js
+++ b/test/util.tmp.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const BB = require('bluebird')
+const requireInject = require('require-inject')
 
 const fs = BB.promisifyAll(require('graceful-fs'))
 const path = require('path')
@@ -8,7 +9,12 @@ const test = require('tap').test
 
 const CACHE = require('./util/test-dir')(__filename)
 
-const tmp = require('../lib/util/tmp')
+const mockedFixOwner = () => Promise.resolve(1)
+// temporarily points to original mkdirfix implementation
+mockedFixOwner.mkdirfix = require('../lib/util/fix-owner').mkdirfix
+const tmp = requireInject('../lib/util/tmp', {
+  '../lib/util/fix-owner': mockedFixOwner
+})
 
 test('creates a unique tmpdir inside the cache', t => {
   return tmp.mkdir(CACHE).then(dir => {
@@ -38,5 +44,14 @@ test('provides a utility that does resource disposal on tmp', t => {
   })
 })
 
-test('makes sure ownership is correct')
-test('provides a function for fixing ownership in the tmp dir')
+test('withTmp should accept both opts and cb params', t => {
+  return tmp.withTmp(CACHE, { tmpPrefix: {} }, dir => {
+    t.ok(dir, 'dir should contain a valid response')
+  })
+})
+
+test('provides a function for fixing ownership in the tmp dir', t => {
+  return tmp.fix(CACHE).then(res => {
+    t.ok(res, 'fixOwner is successfully called')
+  })
+})


### PR DESCRIPTION
Added test coverage for the few lines missing it in `lib/util/tmpjs`

**Notes:**
- Used `requireInject` in order to mock internal calls to `lib/util/fix-owner`
- `lib/util/fix-owner` is in dare need of coverage but I would prefer to tackle it in its own unit tests file
- Unfortunately `fix-owner/mkdirfix` is currently being used by the existing tests, once we have full coverage in `lib/util/fix-owner` we could potentially just mock it too and have a bit of more simplified tests here