### PR TITLE
Remove redundant if statement in lib/memoization

### DIFF
--- a/lib/memoization.js
+++ b/lib/memoization.js
@@ -11,9 +11,7 @@ const MEMOIZED = new LRU({
   length: (entry, key) => {
     if (key.startsWith('key:')) {
       return entry.data.length
-    }
-
-    if (key.startsWith('digest:')) {
+    } else {
       return entry.length
     }
   }

--- a/lib/memoization.js
+++ b/lib/memoization.js
@@ -8,13 +8,7 @@ const MAX_AGE = 3 * 60 * 1000
 const MEMOIZED = new LRU({
   max: MAX_SIZE,
   maxAge: MAX_AGE,
-  length: (entry, key) => {
-    if (key.startsWith('key:')) {
-      return entry.data.length
-    } else {
-      return entry.length
-    }
-  }
+  length: (entry, key) => key.startsWith('key:') ? entry.data.length : entry.length
 })
 
 module.exports.clearMemoized = clearMemoized


### PR DESCRIPTION
Removes redundant `if` statement in the `lib/memoization.js` module that was impossible to unit test in order to get full code coverage in tests (and clean up the module 😊 ).
