### PR TITLE
test(move-file): Added test to renaming fallback

### DIFF
--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -25,9 +25,11 @@ function moveFile (src, dest) {
       if (err) {
         if (err.code === 'EEXIST' || err.code === 'EBUSY') {
           // file already exists, so whatever
-        }/* istanbul ignore next */ else if (err.code === 'EPERM' && process.platform === 'win32') {
-          // file handle stayed open even past graceful-fs limits
         } else {
+          /* istanbul ignore next */
+          if (err.code === 'EPERM' && process.platform === 'win32') {
+            // file handle stayed open even past graceful-fs limits
+          }
           return reject(err)
         }
       }

--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -23,10 +23,9 @@ function moveFile (src, dest) {
   return new Promise((resolve, reject) => {
     fs.link(src, dest, (err) => {
       if (err) {
-        /* istanbul ignore else */
         if (err.code === 'EEXIST' || err.code === 'EBUSY') {
           // file already exists, so whatever
-        } else if (err.code === 'EPERM' && process.platform === 'win32') {
+        }/* istanbul ignore next */ else if (err.code === 'EPERM' && process.platform === 'win32') {
           // file handle stayed open even past graceful-fs limits
         } else {
           return reject(err)

--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -23,6 +23,7 @@ function moveFile (src, dest) {
   return new Promise((resolve, reject) => {
     fs.link(src, dest, (err) => {
       if (err) {
+        /* istanbul ignore else */
         if (err.code === 'EEXIST' || err.code === 'EBUSY') {
           // file already exists, so whatever
         } else if (err.code === 'EPERM' && process.platform === 'win32') {


### PR DESCRIPTION
- Added test that covers the untested renaming fallback using the move-concurrently module, it uses `requireInject` in order to mock `fs`
calls and trigger the correct steps necessary
- Added an istanbul ignore line in order to alleviate the burden on testing very specific platform-dependent errors
- Bumps `lib/util/move-file.js` module to 100% coverage