### PR TITLE
chore: Removes unnecessary if block

### DIFF
--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -238,9 +238,7 @@ function withContentSriSync (cache, integrity, fn) {
         lastErr = err
       }
     }
-    if (lastErr) {
-      throw lastErr
-    }
+    throw lastErr
   }
 }
 


### PR DESCRIPTION
Small refactor on `lib/content/read.js` that removes an unnecessary if block.

- Given the `digests.length <= 1` check that determines `sri[sri.pickAlgorithm()]` has to have more than 1 item in this branch of the logic
- Given that inside that `for of` loop the function is either going to `return` or set a `lastErr`
- The `if (lastErr)` check is thus unnecessary