### PR TITLE
chore: Removes unnecessary check for error

### DIFF
--- a/lib/content/read.js
+++ b/lib/content/read.js
@@ -201,10 +201,7 @@ function withContentSri (cache, integrity, fn) {
           }
 
           // Throw generic error
-          const genericError = results.find((r) => r instanceof Error)
-          if (genericError) {
-            throw genericError
-          }
+          throw results.find((r) => r instanceof Error)
         })
     }
   }


### PR DESCRIPTION
Small refactor on lib/content/read.js `withContentSri` method that removes an unnecessary if check before throwing remaining errors.

- Given the `digests.length <= 1` check that determines `sri[sri.pickAlgorithm()]` has to have more than 1 item in this branch of the logic
- Given that any non error results would have resulted in an early `return result`
- The `if (genericError)` check is thus unnecessary