### PR TITLE
Don't split contents over multiple directories

### DIFF
--- a/lib/content/path.js
+++ b/lib/content/path.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const contentVer = require('../../package.json')['cache-version'].content
-const hashToSegments = require('../util/hash-to-segments')
 const path = require('path')
 const ssri = require('ssri')
 
 // Current format of content file path:
 //
 // sha512-BaSE64Hex= ->
-// ~/.my-cache/content-v2/sha512/ba/da/55deadbeefc0ffee
+// ~/.my-cache/content-v3/sha512-bada55deadbeefc0ffee
 //
 module.exports = contentPath
 
@@ -17,8 +16,7 @@ function contentPath (cache, integrity) {
   // contentPath is the *strongest* algo given
   return path.join(
     contentDir(cache),
-    sri.algorithm,
-    ...hashToSegments(sri.hexDigest())
+    sri.algorithm + '-' + sri.hexDigest()
   )
 }
 

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -10,7 +10,6 @@ const path = require('path')
 const ssri = require('ssri')
 const contentPath = require('./content/path')
 const fixOwner = require('./util/fix-owner')
-const hashToSegments = require('./util/hash-to-segments')
 const indexV = require('../package.json')['cache-version'].index
 
 const appendFile = util.promisify(fs.appendFile)
@@ -160,40 +159,28 @@ function lsStream (cache) {
   const indexDir = bucketDir(cache)
   const stream = new Minipass({ objectMode: true })
 
-  readdirOrEmpty(indexDir).then(buckets => Promise.all(
-    buckets.map(bucket => {
-      const bucketPath = path.join(indexDir, bucket)
-      return readdirOrEmpty(bucketPath).then(subbuckets => Promise.all(
-        subbuckets.map(subbucket => {
-          const subbucketPath = path.join(bucketPath, subbucket)
-
-          // "/cachename/<bucket 0xFF>/<bucket 0xFF>./*"
-          return readdirOrEmpty(subbucketPath).then(entries => Promise.all(
-            entries.map(entry => {
-              const entryPath = path.join(subbucketPath, entry)
-              return bucketEntries(entryPath).then(entries =>
-                // using a Map here prevents duplicate keys from
-                // showing up twice, I guess?
-                entries.reduce((acc, entry) => {
-                  acc.set(entry.key, entry)
-                  return acc
-                }, new Map())
-              ).then(reduced => {
-                // reduced is a map of key => entry
-                for (const entry of reduced.values()) {
-                  const formatted = formatEntry(cache, entry)
-                  if (formatted) {
-                    stream.write(formatted)
-                  }
-                }
-              }).catch(err => {
-                if (err.code === 'ENOENT') { return undefined }
-                throw err
-              })
-            })
-          ))
-        })
-      ))
+  readdirOrEmpty(indexDir).then(entries => Promise.all(
+    entries.map(entry => {
+      const entryPath = path.join(indexDir, entry)
+      return bucketEntries(entryPath).then(entries =>
+        // using a Map here prevents duplicate keys from
+        // showing up twice, I guess?
+        entries.reduce((acc, entry) => {
+          acc.set(entry.key, entry)
+          return acc
+        }, new Map())
+      ).then(reduced => {
+        // reduced is a map of key => entry
+        for (const entry of reduced.values()) {
+          const formatted = formatEntry(cache, entry)
+          if (formatted) {
+            stream.write(formatted)
+          }
+        }
+      }).catch(err => {
+        if (err.code === 'ENOENT') { return undefined }
+        throw err
+      })
     })
   ))
     .then(
@@ -260,10 +247,7 @@ module.exports.bucketPath = bucketPath
 
 function bucketPath (cache, key) {
   const hashed = hashKey(key)
-  return path.join.apply(
-    path,
-    [bucketDir(cache)].concat(hashToSegments(hashed))
-  )
+  return path.join(bucketDir(cache), hashed)
 }
 
 module.exports.hashKey = hashKey

--- a/lib/util/hash-to-segments.js
+++ b/lib/util/hash-to-segments.js
@@ -1,7 +1,0 @@
-'use strict'
-
-module.exports = hashToSegments
-
-function hashToSegments (hash) {
-  return [hash.slice(0, 2), hash.slice(2, 4), hash.slice(4)]
-}

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -122,7 +122,7 @@ function garbageCollect (cache, opts) {
     indexStream.on('end', resolve).on('error', reject)
   }).then(() => {
     const contentDir = contentPath.contentDir(cache)
-    return glob(path.join(contentDir, '**'), {
+    return glob(contentDir + '/*', {
       follow: false,
       nodir: true,
       nosort: true
@@ -137,9 +137,9 @@ function garbageCollect (cache, opts) {
         pMap(
           files,
           (f) => {
-            const split = f.split(/[/\\]/)
-            const digest = split.slice(split.length - 3).join('')
-            const algo = split[split.length - 4]
+            const split = path.basename(f).split('-')
+            const algo = split.shift()
+            const digest = split.join('-')
             const integrity = ssri.fromHex(digest, algo)
             if (liveContent.has(integrity.toString())) {
               return verifyContent(f, integrity).then((info) => {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "cacache",
   "version": "13.0.1",
   "cache-version": {
-    "content": "2",
-    "index": "5"
+    "content": "3",
+    "index": "6"
   },
   "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
   "main": "index.js",


### PR DESCRIPTION
Fix #19

Idea via @wmertens

I'd like to get this library to 100% test coverage before landing this, as it's quite a significant storage architecture shift.

It'd perhaps be nice to have `verify` remove older content/index folders, since they're just garbage if no one is using them.  We could then expose that as a `npm cache` command.