### PR TITLE
test: Add to lib/verify.js test coverage

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -50,7 +50,7 @@ function verify (cache, opts) {
 
   return steps
     .reduce((promise, step, i) => {
-      const label = step.name || `step #${i}`
+      const label = step.name
       const start = new Date()
       return promise.then((stats) => {
         return step(cache, opts).then((s) => {
@@ -208,6 +208,7 @@ function rebuildIndex (cache, opts) {
     }
     const buckets = {}
     for (const k in entries) {
+      /* istanbul ignore else */
       if (hasOwnProperty(entries, k)) {
         const hashed = index.hashKey(k)
         const entry = entries[k]


### PR DESCRIPTION
- Adds missing tests for unknown errors when validating, checking sri streams and rebuilding buckets
- Add checks for hash collisions
- Brings test coverage of `lib/verify.js` to 100%