### PR TITLE
feat: expose index.insert, implement and expose index.compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ just as easily be used on its own.
     * [`rm.all`](#rm-all)
     * [`rm.entry`](#rm-entry)
     * [`rm.content`](#rm-content)
+    * [`index.compact`](#index-compact)
+    * [`index.insert`](#index-insert)
   * Utilities
     * [`clearMemoized`](#clear-memoized)
     * [`tmp.mkdir`](#tmp-mkdir)
@@ -488,6 +490,25 @@ cacache.rm.content(cachePath, 'sha512-SoMeDIGest/IN+BaSE64==').then(() => {
   console.log('data for my-thing is gone!')
 })
 ```
+
+#### <a name="index-compact"></a> `> cacache.index.compact(cache, key, matchFn) -> Promise`
+
+Uses `matchFn`, which must be a synchronous function that accepts two entries
+and returns a boolean indicating whether or not the two entries match, to
+deduplicate all entries in the cache for the given `key`.
+
+The deduplicated list of entries is both written to the index, replacing the
+existing content, and returned in the Promise.
+
+#### <a name="index-insert"></a> `> cacache.index.insert(cache, key, integrity, opts) -> Promise`
+
+Writes an index entry to the cache for the given `key` without writing content.
+
+It is assumed if you are using this method, you have already stored the content
+some other way and you only wish to add a new index to that content. The `metadata`
+and `size` properties are read from `opts` and used as part of the index entry.
+
+Returns a Promise resolving to the newly added entry.
 
 #### <a name="clear-memoized"></a> `> cacache.clearMemoized()`
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ const rm = require('./rm.js')
 const verify = require('./verify.js')
 const { clearMemoized } = require('./lib/memoization.js')
 const tmp = require('./lib/util/tmp.js')
+const index = require('./lib/entry-index.js')
+
+module.exports.index = {}
+module.exports.index.compact = index.compact
+module.exports.index.insert = index.insert
 
 module.exports.ls = ls
 module.exports.ls.stream = ls.stream

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -1,20 +1,25 @@
 'use strict'
 
 const util = require('util')
-
 const crypto = require('crypto')
 const fs = require('fs')
 const Minipass = require('minipass')
 const path = require('path')
 const ssri = require('ssri')
+const uniqueFilename = require('unique-filename')
+
+const { disposer } = require('./util/disposer')
 const contentPath = require('./content/path')
 const fixOwner = require('./util/fix-owner')
 const hashToSegments = require('./util/hash-to-segments')
 const indexV = require('../package.json')['cache-version'].index
+const moveFile = require('@npmcli/move-file')
+const rimraf = util.promisify(require('rimraf'))
 
 const appendFile = util.promisify(fs.appendFile)
 const readFile = util.promisify(fs.readFile)
 const readdir = util.promisify(fs.readdir)
+const writeFile = util.promisify(fs.writeFile)
 
 module.exports.NotFoundError = class NotFoundError extends Error {
   constructor (cache, key) {
@@ -23,6 +28,64 @@ module.exports.NotFoundError = class NotFoundError extends Error {
     this.cache = cache
     this.key = key
   }
+}
+
+module.exports.compact = compact
+
+async function compact (cache, key, matchFn, opts = {}) {
+  const bucket = bucketPath(cache, key)
+  const entries = await bucketEntries(bucket)
+  // reduceRight because the bottom-most result is the newest
+  // since we add new entries with appendFile
+  const newEntries = entries.reduceRight((acc, newEntry) => {
+    if (!acc.find((oldEntry) => matchFn(oldEntry, newEntry))) {
+      acc.push(newEntry)
+    }
+
+    return acc
+  }, [])
+
+  const newIndex = '\n' + newEntries.map((entry) => {
+    const stringified = JSON.stringify(entry)
+    const hash = hashEntry(stringified)
+    return `${hash}\t${stringified}`
+  }).join('\n')
+
+  const setup = async () => {
+    const target = uniqueFilename(path.join(cache, 'tmp'), opts.tmpPrefix)
+    await fixOwner.mkdirfix(cache, path.dirname(target))
+    return {
+      target,
+      moved: false
+    }
+  }
+
+  const teardown = async (tmp) => {
+    if (!tmp.moved) {
+      return rimraf(tmp.target)
+    }
+  }
+
+  const write = async (tmp) => {
+    await writeFile(tmp.target, newIndex, { flag: 'wx' })
+    await fixOwner.mkdirfix(cache, path.dirname(bucket))
+    // we use @npmcli/move-file directly here because we
+    // want to overwrite the existing file
+    await moveFile(tmp.target, bucket)
+    tmp.moved = true
+    try {
+      await fixOwner.chownr(cache, bucket)
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
+    }
+  }
+
+  // write the file atomically
+  await disposer(setup(), teardown, write)
+
+  return newEntries.map((entry) => formatEntry(cache, entry))
 }
 
 module.exports.insert = insert
@@ -209,9 +272,13 @@ function ls (cache) {
   )
 }
 
+module.exports.bucketEntries = bucketEntries
+
 function bucketEntries (bucket, filter) {
   return readFile(bucket, 'utf8').then((data) => _bucketEntries(data, filter))
 }
+
+module.exports.bucketEntries.sync = bucketEntriesSync
 
 function bucketEntriesSync (bucket, filter) {
   const data = fs.readFileSync(bucket, 'utf8')

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -85,7 +85,7 @@ async function compact (cache, key, matchFn, opts = {}) {
   // write the file atomically
   await disposer(setup(), teardown, write)
 
-  return newEntries.map((entry) => formatEntry(cache, entry))
+  return newEntries.map((entry) => formatEntry(cache, entry, true))
 }
 
 module.exports.insert = insert
@@ -346,15 +346,15 @@ function hash (str, digest) {
     .digest('hex')
 }
 
-function formatEntry (cache, entry) {
+function formatEntry (cache, entry, keepAll) {
   // Treat null digests as deletions. They'll shadow any previous entries.
-  if (!entry.integrity) {
+  if (!entry.integrity && !keepAll) {
     return null
   }
   return {
     key: entry.key,
     integrity: entry.integrity,
-    path: contentPath(cache, entry.integrity),
+    path: entry.integrity ? contentPath(cache, entry.integrity) : undefined,
     size: entry.size,
     time: entry.time,
     metadata: entry.metadata

--- a/test/entry-index.js
+++ b/test/entry-index.js
@@ -60,19 +60,21 @@ test('compact', async (t) => {
     index.insert(CACHE, KEY, INTEGRITY, { metadata: { rev: 1 } }),
     index.insert(CACHE, KEY, INTEGRITY, { metadata: { rev: 2 } }),
     index.insert(CACHE, KEY, INTEGRITY, { metadata: { rev: 2 } }),
-    index.insert(CACHE, KEY, INTEGRITY, { metadata: { rev: 1 } })
+    index.insert(CACHE, KEY, INTEGRITY, { metadata: { rev: 1 } }),
+    // compact will return entries with a null integrity
+    index.insert(CACHE, KEY, null, { metadata: { rev: 3 } })
   ])
 
   const bucket = index.bucketPath(CACHE, KEY)
   const entries = await index.bucketEntries(bucket)
-  t.equal(entries.length, 4, 'started with 4 entries')
+  t.equal(entries.length, 5, 'started with 5 entries')
 
   const filter = (entryA, entryB) => entryA.metadata.rev === entryB.metadata.rev
   const compacted = await index.compact(CACHE, KEY, filter)
-  t.equal(compacted.length, 2, 'should return only two entries')
+  t.equal(compacted.length, 3, 'should return only three entries')
 
   const newEntries = await index.bucketEntries(bucket)
-  t.equal(newEntries.length, 2, 'bucket was deduplicated')
+  t.equal(newEntries.length, 3, 'bucket was deduplicated')
 })
 
 test('compact: ENOENT in chownr does not cause failure', async (t) => {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This change implements two new features that will allow us to both compact existing cache indexes and manually append new indexes without having to go through the current hoops of reading the existing content and writing it back.

I elected to only export the two methods that I intend to consume in make-fetch-happen in order to keep the public API of this module to a minimum, allowing us to avoid breaking changes if some internals are refactored.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to npm/statusboard#357