### PR TITLE
chore(ci): use npm7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-
+      - name: Update npm to latest
+        run: npm i -g npm@latest
       ################################################################################
       # Install Dependencies
       #


### PR DESCRIPTION
npm@6 does not install peerDeps the same way.