### PR TITLE
chore: bump @npmcli/fs to supress warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.3.0",
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^1.0.0",
+        "@npmcli/fs": "^1.1.1",
         "@npmcli/move-file": "^1.0.1",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -645,9 +645,9 @@
       }
     },
     "node_modules/@npmcli/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -7580,9 +7580,9 @@
       "dev": true
     },
     "@npmcli/fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "requires": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@npmcli/fs": "^1.0.0",
+    "@npmcli/fs": "^1.1.1",
     "@npmcli/move-file": "^1.0.1",
     "chownr": "^2.0.0",
     "fs-minipass": "^2.0.0",


### PR DESCRIPTION
When installing different packages that depend on cacache we get dep warnings about @npmcli/fs@1.1.0

## References
```
npm WARN deprecated @npmcli/fs@1.1.0: this version had an improper engines field added, update to 1.1.1
```
