### PR TITLE
feat: allow external integrity/size source

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,19 @@ with an `EINTEGRITY` error.
 
 `algorithms` has no effect if this option is present.
 
+##### `opts.integrityEmitter`
+
+*Streaming only* If present, uses the provided event emitter as a source of
+truth for both integrity and size. This allows use cases where integrity is
+already being calculated outside of cacache to reuse that data instead of
+calculating it a second time.
+
+The emitter must emit both the `'integrity'` and `'size'` events.
+
+NOTE: If this option is provided, you must verify that you receive the correct
+integrity value yourself and emit an `'error'` event if there is a mismatch.
+[ssri Integrity Streams](https://github.com/npm/ssri#integrity-stream) do this for you when given an expected integrity.
+
 ##### `opts.algorithms`
 
 Default: ['sha512']

--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const events = require('events')
 const util = require('util')
 
 const contentPath = require('./path')
@@ -114,6 +115,20 @@ async function handleContent (inputStream, cache, opts) {
 }
 
 async function pipeToTmp (inputStream, cache, tmpTarget, opts) {
+  const outStream = new fsm.WriteStream(tmpTarget, {
+    flags: 'wx',
+  })
+
+  if (opts.integrityEmitter) {
+    // we need to create these all simultaneously since they can fire in any order
+    const [integrity, size] = await Promise.all([
+      events.once(opts.integrityEmitter, 'integrity').then(res => res[0]),
+      events.once(opts.integrityEmitter, 'size').then(res => res[0]),
+      new Pipeline(inputStream, outStream).promise(),
+    ])
+    return { integrity, size }
+  }
+
   let integrity
   let size
   const hashStream = ssri.integrityStream({
@@ -128,19 +143,7 @@ async function pipeToTmp (inputStream, cache, tmpTarget, opts) {
     size = s
   })
 
-  const outStream = new fsm.WriteStream(tmpTarget, {
-    flags: 'wx',
-  })
-
-  // NB: this can throw if the hashStream has a problem with
-  // it, and the data is fully written.  but pipeToTmp is only
-  // called in promisory contexts where that is handled.
-  const pipeline = new Pipeline(
-    inputStream,
-    hashStream,
-    outStream
-  )
-
+  const pipeline = new Pipeline(inputStream, hashStream, outStream)
   await pipeline.promise()
   return { integrity, size }
 }


### PR DESCRIPTION
this feature allows us to pass our own event emitter that emits both the 'size' and 'integrity' events and avoid the creation of an internal integrity stream.

the immediate use case for this is in make-fetch-happen, where we already have an integrity stream in place. by passing the events in this way, we avoid calculating hashes multiple times thereby improving performance
