### PR TITLE
chore: use non-legacy hash in test

### DIFF
--- a/test/content/read.js
+++ b/test/content/read.js
@@ -74,7 +74,7 @@ t.test('read.stream: returns a stream with cache content data', function (t) {
 
 t.test('read: allows hashAlgorithm configuration', function (t) {
   const CONTENT = Buffer.from('foobarbaz')
-  const HASH = 'whirlpool'
+  const HASH = 'sha384'
   const INTEGRITY = ssri.fromData(CONTENT, { algorithms: [HASH] })
   const CACHE = t.testdir(
     CacheContent({


### PR DESCRIPTION
Especially since openssl 3 is out.
List of non-legacy ones: `openssl list -digest-algorithms`
