### PR TITLE
fix: file moving on Android

### DIFF
--- a/lib/util/move-file.js
+++ b/lib/util/move-file.js
@@ -31,6 +31,10 @@ async function moveFile (src, dest) {
       // really what we want to do here.
     } else if (err.code === 'EEXIST' || err.code === 'EBUSY') {
       // file already exists, so whatever
+    } else if (process.platform === 'android' && err.code === 'EACCES') {
+      // Android doesn't support hard links, so we get EACCES when trying
+      // to link.
+      return move(src, dest)
     } else {
       throw err
     }

--- a/test/util/move-file.js
+++ b/test/util/move-file.js
@@ -112,7 +112,11 @@ t.test('fallback to renaming on missing files post-move', async t => {
   )
 })
 
-t.test('non ENOENT error on move fallback', async function (t) {
+t.test('non ENOENT error on move fallback', {
+  skip: process.platform === 'android'
+    ? 'The move fallback is unreachable on Android.'
+    : false,
+}, async function (t) {
   const testDir = t.testdir({
     src: 'foo',
   })


### PR DESCRIPTION
The `moveFile()` function tries to make a hard link which isn't supported on Android, which results in a `EACCES` error, so call `move()` directly when running on Android.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes https://github.com/npm/cacache/issues/155