### PR TITLE
fix(verify): allow for entries with multiple hashes

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -100,7 +100,11 @@ async function garbageCollect (cache, opts) {
       return
     }
 
-    liveContent.add(entry.integrity.toString())
+    // integrity is stringified, re-parse it so we can get each hash
+    const integrity = ssri.parse(entry.integrity)
+    for (const algo in integrity) {
+      liveContent.add(integrity[algo].toString())
+    }
   })
   await new Promise((resolve, reject) => {
     indexStream.on('end', resolve).on('error', reject)


### PR DESCRIPTION
Closes: https://github.com/npm/cacache/issues/27