### PR TITLE
fix: don't clobber time when verifying cache

### DIFF
--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -109,12 +109,12 @@ async function compact (cache, key, matchFn, opts = {}) {
 module.exports.insert = insert
 
 async function insert (cache, key, integrity, opts = {}) {
-  const { metadata, size } = opts
+  const { metadata, size, time } = opts
   const bucket = bucketPath(cache, key)
   const entry = {
     key,
     integrity: integrity && ssri.stringify(integrity),
-    time: Date.now(),
+    time: time || Date.now(),
     size,
     metadata,
   }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -224,6 +224,7 @@ async function rebuildBucket (cache, bucket, stats, opts) {
       await index.insert(cache, entry.key, entry.integrity, {
         metadata: entry.metadata,
         size: entry.size,
+        time: entry.time,
       })
       stats.totalEntries++
     } catch (err) {

--- a/test/verify.js
+++ b/test/verify.js
@@ -400,3 +400,13 @@ t.test('handles multiple hashes of the same content', async t => {
   t.match(ls.test.integrity, 'sha512')
   t.match(ls.test.integrity, 'sha256')
 })
+
+t.test('does not clobber entry time', async t => {
+  const cache = t.testdir()
+  const content = Buffer.from('CONTENT!', 'utf8')
+  await cacache.put(cache, 'test', content)
+  const entryBefore = await cacache.get.info(cache, 'test')
+  await cacache.verify(cache)
+  const entryAfter = await cacache.get.info(cache, 'test')
+  t.equal(entryBefore.time, entryAfter.time, 'time does not change')
+})


### PR DESCRIPTION
Closes: https://github.com/npm/cacache/issues/54