### PR TITLE
fix: normalize win32 paths to use on glob expressions

### DIFF
--- a/lib/util/glob.js
+++ b/lib/util/glob.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { glob } = require('glob')
+const path = require('path')
 
-const globify = (pattern) => pattern.split('//').join('/')
+const globify = (pattern) => pattern.split(path.win32.sep).join(path.posix.sep)
 module.exports = (path, options) => glob(globify(path), options)


### PR DESCRIPTION
## What

While testing `cacache.verify` I found that on Windows the `stats` returned by it are not properly reported. Moreover, I found that `cacache.verify` fails to delete files if no cache entries refer to them. 

`cacache.rm.all` also fails to work on Windows: the cache is not cleared after calling this function.

## Why

The root of the problem is the same: `globify` function is not replacing to forward-slashes as [`glob` library is expecting to handle Windows paths](https://github.com/isaacs/node-glob#windows).

I found that originally `globify` was at `lib/verify.js`, the replacement [of the forward-slashes was made correctly](https://github.com/npm/cacache/pull/101/files#diff-eeac8636d9b6fc8549cda5929066bc44196ae8b9daac1f414fdd61e2e1340db6R16).

```javascript
const globify = pattern => pattern.split('\\').join('/')
```

But when created the file `lib/util/glob.js` and moved `globify` there, it [was changed](https://github.com/npm/cacache/pull/141/files#diff-20cceb346ffab6392d2b141017e1aa137df33c1c3ce59d5ccc765171586919f4R6) to 

```javascript
const globify = pattern => pattern.split('//').join('/')
```

which is causing problems when `glob` is used for obtaining stats and cleanup in the case of [`verify`](https://github.com/npm/cacache/blob/13a4ba3423d8d33b7d718e7200e5d3a5ec720a6d/lib/verify.js#L113) and delete the cache with [rm.all](https://github.com/npm/cacache/blob/13a4ba3423d8d33b7d718e7200e5d3a5ec720a6d/lib/rm.js#L29)

## Change details

Replace backslash by forward-slashes if they are present on a path before calling `glob`.

Initially I was going to rollback the change to the first implementation of `globify`, but I though it would be more explicit to use [path.sep](https://nodejs.org/api/path.html#pathsep).

## Issues reported

[BUG] rm.all doesn't delete anything on Windows #165


