### PR TITLE
fix: attach a catch handler to the handleContentP promise

### DIFF
--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -67,7 +67,7 @@ class CacacheWriteStream extends Flush {
         this.cache,
         this.opts
       )
-      this.handleContentP.catch(error => this.destroy(error))
+      this.handleContentP.catch(error => this.emit('error', error))
     }
     return this.inputStream.write(chunk, encoding, cb)
   }

--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -67,6 +67,7 @@ class CacacheWriteStream extends Flush {
         this.cache,
         this.opts
       )
+      this.handleContentP.catch(error => this.destroy(error))
     }
     return this.inputStream.write(chunk, encoding, cb)
   }


### PR DESCRIPTION
This attaches a catch handler to the handleContentP promise, as in some cases the flush is not called before node decides that this is an unhandled promise rejection.

Fixes #249