### PR TITLE
fix: Remove usage of `p-map`

### DIFF
--- a/lib/util/map-with-promise.js
+++ b/lib/util/map-with-promise.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * Map over a iterable with a concurrency limit, returning a promise that
+ * resolves when all items have been processed.
+ *
+ * @param {Iterable} items iterable of items to process
+ * @param {number} concurrency number of items to process concurrently
+ * @param {Function} callback function to process each item
+ * @returns {Promise} promise that resolves when all items have been processed
+ */
+function mapWithPromise (items, concurrency, callback) {
+  const iterator = items[Symbol.iterator]()
+  return Promise.all(
+    Array(concurrency)
+      .fill(iterator)
+      .map(async (iter) => {
+        for (const [index, item] of iter) {
+          await callback(item, index)
+        }
+      })
+  )
+}
+
+module.exports = mapWithPromise

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -8,10 +8,10 @@ const {
   truncate,
   writeFile,
 } = require('fs/promises')
-const pMap = require('p-map')
 const contentPath = require('./content/path')
 const fsm = require('fs-minipass')
 const glob = require('./util/glob.js')
+const mapWithPromise = require('./util/map-with-promise.js')
 const index = require('./entry-index')
 const path = require('path')
 const ssri = require('ssri')
@@ -122,8 +122,10 @@ async function garbageCollect (cache, opts) {
     badContentCount: 0,
     keptSize: 0,
   }
-  await pMap(
+
+  await mapWithPromise(
     files,
+    opts.concurrency,
     async (f) => {
       const split = f.split(/[/\\]/)
       const digest = split.slice(split.length - 3).join('')
@@ -146,9 +148,7 @@ async function garbageCollect (cache, opts) {
         await rm(f, { recursive: true, force: true })
         stats.reclaimedSize += s.size
       }
-      return stats
-    },
-    { concurrency: opts.concurrency }
+    }
   )
   return stats
 }
@@ -203,12 +203,12 @@ async function rebuildIndex (cache, opts) {
       }
     }
   }
-  await pMap(
+  await mapWithPromise(
     Object.keys(buckets),
+    opts.concurrency,
     (key) => {
       return rebuildBucket(cache, buckets[key], stats, opts)
-    },
-    { concurrency: opts.concurrency }
+    }
   )
   return stats
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "minipass-collect": "^2.0.1",
     "minipass-flush": "^1.0.5",
     "minipass-pipeline": "^1.2.4",
-    "p-map": "^4.0.0",
     "ssri": "^10.0.0",
     "tar": "^6.1.11",
     "unique-filename": "^3.0.0"


### PR DESCRIPTION
When [investigating reducing the dependency count](https://github.com/semantic-release/semantic-release/discussions/3376#discussioncomment-9931465) for the semantic-release library, I discovered that `npm` has quite the large dependency tree: https://github.com/43081j/ecosystem-cleanup/issues/64

One area of improvement here is to remove the dependency on the `p-map` library and replace it with a smaller, simpler helper.

Right now `cacache` relies on `p-map@4.0.0`, which pulls in `aggregate-error@3.1.0`. Newer versions of `p-map` don't pull this in `aggregate-error` at all, but that is not feasible to use because this `cacache` is CJS only, and `p-map` `5.x` and above are ESM only.

Given `cacache` supports `"^16.14.0 || >=18.0.0"` as per it's `package.json` `engines` field, it doesn't make sense for it to pull in a polyfill for `aggregate-error` (Node.js 15+ adds support for the built-in `AggregateError`.

To replace `pMap` which we used from the `p-map` library, I introduced a `mapWithPromise` helper. It doesn't have all the functionality of `pMap`, but it works well for the use cases in `lib/verify.js`. In addition it should be slightly faster than `pMap` because of it is simpler. (let me know and I'm happy to bench mark to get exact numbers).

This change should help eliminate 25 KB / 4 deps from the module graph of `cacache`.

## References

Supercedes https://github.com/npm/cacache/pull/266