### PR TITLE
fix: remove unused tar deendency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "minipass-pipeline": "^1.2.4",
     "p-map": "^7.0.2",
     "ssri": "^12.0.0",
-    "tar": "^7.4.3",
     "unique-filename": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It appears that tar is declared in dependencies, but isn't actually used. This causes 2 MB of dependencies to be pulled into one's node_modules on every cacache install.

I was unable to track back when the dependency actually stopped being used; looks like at least several major versions were shipped with it unnecessarily.

If this is confirmed, it'd be great to push this fix to older major versions if possible.