### PR TITLE
chore: replace glob with tinyglobby

### DIFF
--- a/lib/rm.js
+++ b/lib/rm.js
@@ -26,6 +26,13 @@ module.exports.all = all
 
 async function all (cache) {
   memo.clearMemoized()
-  const paths = await glob(path.join(cache, '*(content-*|index-*)'), { silent: true, nosort: true })
+  const paths = await glob('{content-*,index-*}', {
+    absolute: true,
+    cwd: cache,
+    expandDirectories: false,
+    onlyDirectories: true,
+    silent: true,
+    nosort: true
+  })
   return Promise.all(paths.map((p) => rm(p, { recursive: true, force: true })))
 }

--- a/lib/util/glob.js
+++ b/lib/util/glob.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { glob } = require('glob')
+const { glob } = require('tinyglobby')
 const path = require('path')
 
 const globify = (pattern) => pattern.split(path.win32.sep).join(path.posix.sep)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@npmcli/fs": "^4.0.0",
     "fs-minipass": "^3.0.0",
-    "glob": "^11.0.3",
     "lru-cache": "^11.1.0",
     "minipass": "^7.0.3",
     "minipass-collect": "^2.0.1",
@@ -57,6 +56,7 @@
     "p-map": "^7.0.2",
     "ssri": "^12.0.0",
     "tar": "^7.4.3",
+    "tinyglobby": "^0.2.14",
     "unique-filename": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR replaces `glob` with `tinyglobby`, vastly reducing `cacache`'s install size (dependency sizes: 3.36 MB, 158 KB respectively).

It also aligns the package with very popular packages often depending on cacache: for example, fsevents used literally everywhere depends on `node-gyp` which itself uses tinyglobby already. After this PR gets merged, installing fsevents would only pull one globbing library. Wouldn't that be nice?