### PR TITLE
fix: create CACHEDIR.TAG for cache directories

### DIFF
--- a/lib/content/write.js
+++ b/lib/content/write.js
@@ -10,6 +10,7 @@ const Pipeline = require('minipass-pipeline')
 const Flush = require('minipass-flush')
 const path = require('path')
 const ssri = require('ssri')
+const cacheDir = require('../util/cache-dir')
 const { tmpName } = require('../util/tmp')
 const fsm = require('fs-minipass')
 
@@ -153,6 +154,7 @@ async function pipeToTmp (inputStream, cache, tmpTarget, opts) {
 
 async function makeTmp (cache, opts) {
   const tmpTarget = tmpName(cache, opts.tmpPrefix)
+  await cacheDir.mkdir(cache)
   await fs.mkdir(path.dirname(tmpTarget), { recursive: true })
   return {
     target: tmpTarget,

--- a/lib/entry-index.js
+++ b/lib/entry-index.js
@@ -13,6 +13,7 @@ const { Minipass } = require('minipass')
 const path = require('path')
 const ssri = require('ssri')
 const { tmpName } = require('./util/tmp')
+const cacheDir = require('./util/cache-dir')
 
 const contentPath = require('./content/path')
 const hashToSegments = require('./util/hash-to-segments')
@@ -70,6 +71,7 @@ async function compact (cache, key, matchFn, opts = {}) {
 
   const setup = async () => {
     const target = tmpName(cache, opts.tmpPrefix)
+    await cacheDir.mkdir(cache)
     await mkdir(path.dirname(target), { recursive: true })
     return {
       target,
@@ -121,6 +123,7 @@ async function insert (cache, key, integrity, opts = {}) {
     metadata,
   }
   try {
+    await cacheDir.mkdir(cache)
     await mkdir(path.dirname(bucket), { recursive: true })
     const stringified = JSON.stringify(entry)
     // NOTE - Cleverness ahoy!

--- a/lib/rm.js
+++ b/lib/rm.js
@@ -27,5 +27,6 @@ module.exports.all = all
 async function all (cache) {
   memo.clearMemoized()
   const paths = await glob(path.join(cache, '*(content-*|index-*)'), { silent: true, nosort: true })
+  paths.push(path.join(cache, 'CACHEDIR.TAG'))
   return Promise.all(paths.map((p) => rm(p, { recursive: true, force: true })))
 }

--- a/lib/util/cache-dir.js
+++ b/lib/util/cache-dir.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const fs = require('fs/promises')
+const path = require('path')
+
+const tagContent = `Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by cacache.
+# For information about cache directory tags, see https://bford.info/cachedir/
+`
+
+async function mkdir (cache) {
+  await fs.mkdir(cache, { recursive: true, owner: 'inherit' })
+  await writeTag(cache)
+}
+
+async function writeTag (cache) {
+  try {
+    await fs.writeFile(path.join(cache, 'CACHEDIR.TAG'), tagContent, { flag: 'wx' })
+  } catch (err) {
+    if (err.code !== 'EEXIST') {
+      throw err
+    }
+  }
+}
+
+module.exports = {
+  mkdir,
+  tagContent,
+}

--- a/lib/util/tmp.js
+++ b/lib/util/tmp.js
@@ -4,6 +4,7 @@ const crypto = require('crypto')
 const { withTempDir } = require('@npmcli/fs')
 const fs = require('fs/promises')
 const path = require('path')
+const cacheDir = require('./cache-dir')
 
 module.exports.mkdir = mktmpdir
 
@@ -15,6 +16,7 @@ module.exports.tmpName = function tmpName (cache, tmpPrefix) {
 async function mktmpdir (cache, opts = {}) {
   const { tmpPrefix } = opts
   const tmpDir = path.join(cache, 'tmp')
+  await cacheDir.mkdir(cache)
   await fs.mkdir(tmpDir, { recursive: true, owner: 'inherit' })
   // do not use path.join(), it drops the trailing / if tmpPrefix is unset
   const target = `${tmpDir}${path.sep}${tmpPrefix || ''}`
@@ -28,5 +30,7 @@ function withTmp (cache, opts, cb) {
     cb = opts
     opts = {}
   }
-  return withTempDir(path.join(cache, 'tmp'), cb, opts)
+  return cacheDir.mkdir(cache).then(() =>
+    withTempDir(path.join(cache, 'tmp'), cb, opts)
+  )
 }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const {
-  mkdir,
   readFile,
   rm,
   stat,
@@ -12,6 +11,7 @@ const contentPath = require('./content/path')
 const fsm = require('fs-minipass')
 const glob = require('./util/glob.js')
 const index = require('./entry-index')
+const cacheDir = require('./util/cache-dir')
 const path = require('path')
 const ssri = require('ssri')
 
@@ -77,7 +77,7 @@ async function markEndTime () {
 
 async function fixPerms (cache, opts) {
   opts.log.silly('verify', 'fixing cache permissions')
-  await mkdir(cache, { recursive: true })
+  await cacheDir.mkdir(cache)
   return null
 }
 

--- a/test/put.js
+++ b/test/put.js
@@ -24,6 +24,17 @@ t.test('basic bulk insertion', async t => {
   t.same(data, CONTENT, 'content was correctly inserted')
 })
 
+t.test('creates a CACHEDIR.TAG marker on bulk insertion', async t => {
+  const CACHE = t.testdir()
+  await put(CACHE, KEY, CONTENT)
+  const tag = await fs.readFile(path.join(CACHE, 'CACHEDIR.TAG'), 'utf8')
+  t.match(
+    tag,
+    /^Signature: 8a477f597d28d172789f06886806bc55\n/,
+    'cache directory is tagged'
+  )
+})
+
 t.test('basic stream insertion', async t => {
   const CACHE = t.testdir()
   let int

--- a/test/util/cache-dir.js
+++ b/test/util/cache-dir.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const fs = require('fs/promises')
+const path = require('path')
+const t = require('tap')
+
+const cacheDir = require('../../lib/util/cache-dir')
+
+t.test('mkdir creates the cache directory tag', async t => {
+  const cache = t.testdir()
+  await cacheDir.mkdir(cache)
+  const tag = await fs.readFile(path.join(cache, 'CACHEDIR.TAG'), 'utf8')
+  t.equal(tag, cacheDir.tagContent)
+})
+
+t.test('mkdir keeps an existing cache directory tag', async t => {
+  const cache = t.testdir({
+    'CACHEDIR.TAG': 'existing tag',
+  })
+
+  await cacheDir.mkdir(cache)
+  const tag = await fs.readFile(path.join(cache, 'CACHEDIR.TAG'), 'utf8')
+  t.equal(tag, 'existing tag')
+})
+
+t.test('mkdir rethrows unexpected tag write errors', async t => {
+  const cacheDir = t.mock('../../lib/util/cache-dir', {
+    'fs/promises': {
+      mkdir: async () => {},
+      writeFile: async () => {
+        const err = new Error('permission denied')
+        err.code = 'EACCES'
+        throw err
+      },
+    },
+  })
+
+  await t.rejects(cacheDir.mkdir('/cache'), { code: 'EACCES' })
+})


### PR DESCRIPTION
Fixes #293.

This adds a small cache directory helper that writes the standard `CACHEDIR.TAG` marker when cacache creates a cache directory. The tag uses the CACHEDIR.TAG signature so backup/archive tools can identify the cache as recreatable data.

The helper is used by the write, index, temp directory, and verify paths that create cache directories. `rm.all()` also removes the marker along with cacache-managed content and index directories while leaving unrelated files alone.

Verification:

- `npx tap test/put.js test/util/cache-dir.js --no-coverage`
- `npm test --ignore-scripts`
- `npm run lint --ignore-scripts`
- `npm test` runs the tap suite and eslint successfully; the final `template-oss-check` step reports existing template updates needed in `.github/dependabot.yml`, `.github/settings.yml`, and workflow files, which are unrelated to this change.
